### PR TITLE
zlib1g-dev Package

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ _OR_
  * make
 
 #### Note for Debian/Ubuntu users:
- * apt-get install automake autoconf pkg-config libcurl4-openssl-dev libjansson-dev libssl-dev libgmp-dev
+ * apt-get install automake autoconf pkg-config libcurl4-openssl-dev libjansson-dev libssl-dev libgmp-dev zlib1g-dev
 
 #### Notes for AIX users:
  * To build a 64-bit binary, export OBJECT_MODE=64


### PR DESCRIPTION
Add zlib1g-dev in the requirement for ubuntu/debian compilation